### PR TITLE
Properly cleanup on shutdown

### DIFF
--- a/include/rdp/RDPListener.h
+++ b/include/rdp/RDPListener.h
@@ -153,6 +153,11 @@ public:
     std::string CredentialPath();
 
     /**
+     * @brief Shutdown and unregister the listener.
+     */
+    void shutdown();
+
+    /**
      * @brief The freerdp_listener struct this object manages.
      *
      * This is the actual FreeRDP listener struct that holds most of the real internal state of the RDP listener itself.
@@ -247,11 +252,11 @@ private:
     /**
      * @brief Mutex guarding stop.
      */
-    std::mutex stopMutex;
+    std::mutex listenerStopMutex;
     /**
      * @brief Flag to be set when the listener needs to clean up and exit.
      */
-    bool stop;
+    bool listener_running;
     /**
      * @brief DBus id.
      */

--- a/src/RDPServerWorker.cpp
+++ b/src/RDPServerWorker.cpp
@@ -217,7 +217,7 @@ void RDPServerWorker::run()
                     obj.convert(&vec);
                     server->processIncomingMessage(vec);
                 } catch (std::out_of_range &e) {
-                    LOG(ERROR) << "Listener with UUID " << uuid << " does not exist in map!";
+                    LOG(WARNING) << "Listener with UUID " << uuid << " does not exist in map!";
                 } catch (std::exception &e) {
                     LOG(ERROR) << "Msgpack conversion failed: " << e.what();
                     LOG(ERROR) << "Offending buffer is " << unpacked.get();

--- a/src/rdp/RDPListener.cpp
+++ b/src/rdp/RDPListener.cpp
@@ -105,7 +105,13 @@ void RDPListener::RunServer()
         LOG(WARNING) << "LISTENER " << this << ": Unable to create introspection data.";
         goto cleanup;
     }
-    registered_id = dbus_conn->register_object(dbus_name, introspection_data->lookup_interface(), vtable);
+
+    try {
+        registered_id = dbus_conn->register_object(dbus_name, introspection_data->lookup_interface(), vtable);
+    } catch (Gio::Error &e) {
+        LOG(WARNING) << "LISTENER " << this << ": Could not take listener name on bus. Is there a duplicate registered?";
+        goto cleanup;
+    }
 
     this->server->port = this->port;
 


### PR DESCRIPTION
The previous fix had a regression where the main listener wouldn't properly exit and so hung on to its dbus object. This led to a case wherein shutdown events would appear to clean up properly but not really. 