### PR TITLE
Resolve use-after-free issues between listener and subsystem

### DIFF
--- a/include/rdp/RDPListener.h
+++ b/include/rdp/RDPListener.h
@@ -170,6 +170,8 @@ public:
      */
     void *shm_buffer;
 
+    bool listenerRunning();
+
 private:
 
     /**

--- a/src/rdp/subsystem.cpp
+++ b/src/rdp/subsystem.cpp
@@ -237,7 +237,12 @@ void *rdpmux_subsystem_thread(rdpmuxShadowSubsystem *system)
     interval = (DWORD) (1000 / system->captureFrameRate);
     frametime = GetTickCount64() + interval;
 
-    while(1) {
+    while(true) {
+
+        if (!system->listener->listenerRunning()) {
+            break;
+        }
+
         status = WaitForMultipleObjects(nCount, events, FALSE, 5);
 
         if (WaitForSingleObject(stopEvent, 0) == WAIT_OBJECT_0) {


### PR DESCRIPTION
Fixed another use-after-free issue between the subsystem's event handles and the listener when properly shutting down shadow server. 